### PR TITLE
Add an effectful version of recursive example

### DIFF
--- a/examples/effectful/Forest.elm
+++ b/examples/effectful/Forest.elm
@@ -1,0 +1,34 @@
+module Forest exposing (Model, Msg, init, view, update, sub)
+
+import Array exposing (Array)
+import Debug
+import Html exposing (..)
+import TeaCombine exposing (Ix, View, previewEvery)
+import TeaCombine.Effectful exposing (Update, Subscription)
+import TeaCombine.Effectful.Many exposing (updateEach, subscribeEach)
+
+
+type alias Model a =
+    Array a
+
+
+type alias Msg a =
+    Ix a
+
+
+init : List a -> flags -> (Model a, Cmd msg)
+init l _ =
+    ( Array.fromList l, Cmd.none )
+
+
+view : View a b -> View (Model a) (Msg b)
+view viewA =
+    ul [] << previewEvery (\a -> li [] [ viewA a ])
+
+
+update : Update a b -> Update (Model a) (Msg b)
+update = updateEach << always
+
+
+sub : Subscription a b -> Subscription (Model a) (Msg b)
+sub = subscribeEach << always

--- a/examples/effectful/Main.elm
+++ b/examples/effectful/Main.elm
@@ -1,6 +1,7 @@
 module Main exposing (main)
 
 import Browser
+import Either exposing (Either)
 import Html exposing (Html)
 import TeaCombine exposing (..)
 import TeaCombine.Effectful.Pair exposing (..)
@@ -8,13 +9,14 @@ import TicToc
 import Utils
 
 
+main : Program () (Both TicToc.Model TicToc.Model) (Either TicToc.Msg TicToc.Msg)
 main =
     Browser.element
         { init = TicToc.init 500 |> initWith (TicToc.init 250)
         , view =
             Utils.wrapView "Pair of effectful components"
                 (Html.div []
-                    << (joinViews TicToc.view TicToc.view)
+                    << joinViews TicToc.view TicToc.view
                 )
         , update = TicToc.update |> updateWith TicToc.update
         , subscriptions = TicToc.sub |> subscribeWith TicToc.sub

--- a/examples/effectful/Recursive.elm
+++ b/examples/effectful/Recursive.elm
@@ -1,0 +1,116 @@
+module Recursive exposing (main)
+
+import Array exposing (Array)
+import Browser
+import Either exposing (Either(..))
+import Forest
+import Html
+import List
+import Maybe
+import TeaCombine exposing (Both, View, mapBoth, viewBoth)
+import TeaCombine.Effectful exposing (Update)
+import TeaCombine.Effectful.Pair exposing (initWith, updateWith, subscribeWith)
+import TicToc
+import Utils
+
+
+
+{-
+   The root component.
+
+   It has a Counter and a Forest of subtrees, and it draws the former
+   above the latter.
+
+   Elm can not infer the infinite types like `Both a (Many (Both a (Many ...)))`.
+   You are need to provide an auxiliary type, that will help it to "untie"
+   the recursion in types (but will keep recursion in values!).
+-}
+
+
+type Tree
+    = Node (Both TicToc.Model (Forest.Model Tree))
+
+
+
+{-
+   This is a message to Tree. It targets one of tree's subcomponents.
+
+   This is an another "unying type" (see above).
+-}
+
+
+type Msg
+    = Msg (Either TicToc.Msg (Forest.Msg Msg))
+
+
+init : flags -> ( Tree, Cmd Msg )
+init flags =
+    let
+        initNode c f =
+            let
+                ( x, cmd ) =
+                    (TicToc.init c |> initWith (Forest.init f)) flags
+            in
+            ( Node x, cmd )
+
+        ( tree, ct ) =
+            initNode 2000 [ n1, n2 ]
+
+        ( n1, c1 ) =
+            initNode 1000 []
+
+        ( n2, c2 ) =
+            initNode 1000 [ n3 ]
+
+        ( n3, c3 ) =
+            initNode 500 []
+
+        cmds =
+            Cmd.map Msg (Cmd.batch [ ct, c1, c2, c3 ])
+    in
+    ( tree, cmds )
+
+
+view : View Tree Msg
+view =
+    Utils.wrapView "A tree" <|
+        \(Node payload) ->
+            let
+                ( header, contents ) =
+                    viewBoth TicToc.view (Forest.view view) payload
+            in
+            Html.div [] [ header, contents ]
+                |> Html.map Msg
+
+
+update : Update Tree Msg
+update (Msg msg) (Node payload) =
+    let
+        updateTree =
+            TicToc.update
+                |> updateWith (Forest.update update)
+    in
+    updateTree
+        msg
+        payload
+        |> mapBoth Node (Cmd.map Msg)
+
+
+sub : Tree -> Sub Msg
+sub (Node t) =
+    let
+        subTree =
+            TicToc.sub
+                |> subscribeWith (Forest.sub sub)
+    in
+    subTree t |> Sub.map Msg
+
+
+main : Program () Tree Msg
+main =
+    Browser.element
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = sub
+        }

--- a/examples/effectful/TicToc.elm
+++ b/examples/effectful/TicToc.elm
@@ -22,8 +22,8 @@ type Msg
     | Tick
 
 
-init : Float -> () -> ( Model, Cmd Msg )
-init i () =
+init : Float -> flags -> ( Model, Cmd Msg )
+init i _ =
     ( { interval = i
       , state = False
       , enabled = True

--- a/examples/pure/Forest.elm
+++ b/examples/pure/Forest.elm
@@ -5,7 +5,7 @@ import Debug
 import Html exposing (..)
 import TeaCombine exposing (Ix, View, previewEvery)
 import TeaCombine.Pure exposing (Update)
-import TeaCombine.Pure.Many exposing (updateByIndex)
+import TeaCombine.Pure.Many exposing (updateEach)
 
 
 type alias Model a =
@@ -22,8 +22,8 @@ view viewA =
 
 
 update : Update a b -> Update (Model a) (Msg b)
-update updateAB =
-    updateByIndex updateAB
+update =
+    updateEach << always
 
 
 init : List a -> Model a

--- a/src/TeaCombine.elm
+++ b/src/TeaCombine.elm
@@ -6,6 +6,7 @@ module TeaCombine exposing
     , bind, thenBind
     , oneOfViews, orView, oneOfPaths, orPath
     , eitherView
+    , mapBoth
     )
 
 {-| The common types and combinators.
@@ -19,6 +20,7 @@ TODO: add some great docs.
 @docs bind, thenBind
 @docs oneOfViews, orView, oneOfPaths, orPath
 @docs eitherView
+@docs mapBoth
 
 -}
 
@@ -251,3 +253,10 @@ eitherView v2 v1 m =
 
         Right m2 ->
             Html.map Right <| v2 m2
+
+
+{-| Applies two functions to the "sides" of the `Both`.
+-}
+mapBoth : (a -> c) -> (b -> d) -> Both a b -> Both c d
+mapBoth f g ( a, b ) =
+    ( f a, g b )

--- a/src/TeaCombine/Pure/Many.elm
+++ b/src/TeaCombine/Pure/Many.elm
@@ -1,11 +1,11 @@
-module TeaCombine.Pure.Many exposing (updateEach, updateAll, updateByIndex)
+module TeaCombine.Pure.Many exposing (updateEach, updateAll)
 
 {-| Combinators those help to work with homogenous sets of sub-models
 (in a form of @Array).
 
 TODO: add some great docs
 
-@docs updateEach, updateAll, updateByIndex
+@docs updateEach, updateAll
 
 -}
 
@@ -41,17 +41,3 @@ updateAll updates =
                 (Array.get idx uarr)
     in
     updateEach updateAt
-
-
-{-| Updates a sub-model with given index in @Array using a sub-update.
--}
-updateByIndex :
-    Update model msg
-    -> Update (Array model) (Ix msg)
-updateByIndex update (Ix idx msg) model =
-    case Array.get idx model of
-        Just elem ->
-            Array.set idx (update msg elem) model
-
-        Nothing ->
-            model


### PR DESCRIPTION
Closes #4 
Adds `Effectful.Many.subscribeEach`, removes `Pure.Many.updateByIndex` as redundant.
Add an effectful example (recursive tree of tictocs).